### PR TITLE
Fix model id for gemini 2.5 pro

### DIFF
--- a/2025/adk-agentengine-basic/step01/agent.py
+++ b/2025/adk-agentengine-basic/step01/agent.py
@@ -1,6 +1,6 @@
 from google.adk.agents import LlmAgent
 
-MODEL_GEMINI_2_5_PRO="gemini-2.5-PRO"
+MODEL_GEMINI_2_5_PRO="gemini-2.5-pro"
 MODEL_GEMINI_2_5_FLASH="gemini-2.5-flash"
 MODEL_GEMINI_2_5_FLASH_LITE="gemini-2.5-flash-lite"
 

--- a/2025/adk-agentengine-basic/step02/agent.py
+++ b/2025/adk-agentengine-basic/step02/agent.py
@@ -1,7 +1,7 @@
 from google.adk.agents import LlmAgent
 from google.adk.tools.load_web_page import load_web_page
 
-MODEL_GEMINI_2_5_PRO="gemini-2.5-PRO"
+MODEL_GEMINI_2_5_PRO="gemini-2.5-pro"
 MODEL_GEMINI_2_5_FLASH="gemini-2.5-flash"
 MODEL_GEMINI_2_5_FLASH_LITE="gemini-2.5-flash-lite"
 

--- a/2025/adk-agentengine-basic/step03/agent.py
+++ b/2025/adk-agentengine-basic/step03/agent.py
@@ -3,7 +3,7 @@ from google.adk.tools.mcp_tool import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
 from mcp import StdioServerParameters
 
-MODEL_GEMINI_2_5_PRO="gemini-2.5-PRO"
+MODEL_GEMINI_2_5_PRO="gemini-2.5-pro"
 MODEL_GEMINI_2_5_FLASH="gemini-2.5-flash"
 MODEL_GEMINI_2_5_FLASH_LITE="gemini-2.5-flash-lite"
 

--- a/2025/adk-agentengine-basic/step04/agent.py
+++ b/2025/adk-agentengine-basic/step04/agent.py
@@ -4,7 +4,7 @@ from google.adk.tools.mcp_tool import StdioConnectionParams
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
 from mcp import StdioServerParameters
 
-MODEL_GEMINI_2_5_PRO="gemini-2.5-PRO"
+MODEL_GEMINI_2_5_PRO="gemini-2.5-pro"
 MODEL_GEMINI_2_5_FLASH="gemini-2.5-flash"
 MODEL_GEMINI_2_5_FLASH_LITE="gemini-2.5-flash-lite"
 MODEL_GEMINI_2_5_FLASH_PREVIEW_TTS="gemini-2.5-flash-preview-tts"

--- a/2025/adk-agentengine-basic/step05/agent.py
+++ b/2025/adk-agentengine-basic/step05/agent.py
@@ -7,7 +7,7 @@ from mcp import StdioServerParameters
 
 from .tools import podcast_speaker
 
-MODEL_GEMINI_2_5_PRO="gemini-2.5-PRO"
+MODEL_GEMINI_2_5_PRO="gemini-2.5-pro"
 MODEL_GEMINI_2_5_FLASH="gemini-2.5-flash"
 MODEL_GEMINI_2_5_FLASH_LITE="gemini-2.5-flash-lite"
 


### PR DESCRIPTION
Fix model id for gemini 2.5 pro from gemini-2.5-PRO to gemini-2.5-pro